### PR TITLE
Content update

### DIFF
--- a/app/views/apply/application-summary.html
+++ b/app/views/apply/application-summary.html
@@ -144,7 +144,7 @@
         <h2>To complete your application you’ll need to:</h2>
         <ul class="govuk-list govuk-list--bullet">
             <li>fill in your application details</li>
-            <li>pay online for your passport</li>
+            <li>pay for your passport</li>
 
             {# FTC #}
             {% if values.applicationType == "first" and values.adultOrChild == "child" %}

--- a/app/views/filter/intro.html
+++ b/app/views/filter/intro.html
@@ -67,7 +67,7 @@
                         <p>We’ll tell you what documents you need to send.</p>
                     </li>
                     <li>
-                        <h2>Pay for your passport online</h2>
+                        <h2>Pay for your passport</h2>
                         <p>A standard passport is £75.50 for an adult, and £49 for a child.</p>
                     </li>
                     <li>


### PR DESCRIPTION
Content update to remove the word "online" from "pay for your passport" on the how to apply, and application summary pages.